### PR TITLE
Bugfix/dad 365 fix kibana log pattern

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,13 +20,13 @@ import events_protocol
 
 # -- Project information -----------------------------------------------------
 
-project = 'events-protocol'
-copyright = '2020, Guiabolso'
-author = 'Guiabolso'
+project = "events-protocol"
+copyright = "2020, Guiabolso"
+author = "Guiabolso"
 
 autodoc_mock_imports = [
-    'requests',
-    'pydantic',
+    "requests",
+    "pydantic",
 ]
 
 # -- General configuration ---------------------------------------------------
@@ -35,33 +35,30 @@ autodoc_mock_imports = [
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'autoapi.extension',
+    "sphinx.ext.autodoc",
+    "autoapi.extension",
 ]
 
-autodoc_default_options = {
-    'show-inheritance': True,
-    'members': True
-}
+autodoc_default_options = {"show-inheritance": True, "members": True}
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
-    'autoapi_templates',
+    "autoapi_templates",
 ]
 
 # Paths (relative or absolute) to the source code that you wish to generate
 # your API documentation from.
 autoapi_dirs = [
-    os.path.abspath('../../events_protocol'),
+    os.path.abspath("../../events_protocol"),
 ]
 
 # A directory that has user-defined templates to override our default templates.
-autoapi_template_dir = 'autoapi_templates'
+autoapi_template_dir = "autoapi_templates"
 
 # Keep the AutoAPI generated files on the filesystem after the run.
 # Useful for debugging.
@@ -69,7 +66,7 @@ autoapi_keep_files = True
 
 # Relative path to output the AutoAPI files into. This can also be used to place the generated documentation
 # anywhere in your documentation hierarchy.
-autoapi_root = '_api'
+autoapi_root = "_api"
 
 version = events_protocol.__version__
 release = events_protocol.__version__
@@ -79,15 +76,15 @@ release = events_protocol.__version__
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
+html_theme = "default"
 
-html_title = 'Events Protocol'
+html_title = "Events Protocol"
 
-html_favicon = '_static/images/favicon.png'
+html_favicon = "_static/images/favicon.png"
 
-master_doc = 'index'
+master_doc = "index"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/events_protocol/__init__.py
+++ b/events_protocol/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.1"  # pragma: no cover
+__version__ = "0.1.2"

--- a/events_protocol/core/context.py
+++ b/events_protocol/core/context.py
@@ -12,6 +12,8 @@ class EventContext(BaseModel):
     id: typing.Optional[IdType]
     flow_id: typing.Optional[IdType]
     event_name: typing.Optional[str]
+    event_version: typing.Optional[int]
+    user_id: typing.Optional[str]
 
 
 _context: ContextVar[EventContext] = ContextVar("event_context", default=None)
@@ -33,11 +35,20 @@ class EventContextHolder:
     @classmethod
     @contextmanager
     def with_context(
-        cls, context_id: IdType, context_flow_id: IdType, event_name: str, user_id: str = None
+        cls,
+        context_id: IdType,
+        context_flow_id: IdType,
+        event_name: str,
+        event_version: int,
+        user_id: str = None,
     ):
         try:
             event_context = EventContext(
-                id=context_id, flow_id=context_flow_id, event_name=event_name, user_id=user_id
+                id=context_id,
+                flow_id=context_flow_id,
+                event_name=event_name,
+                user_id=user_id,
+                event_version=event_version,
             )
             cls.set(event_context)
             yield cls.get()
@@ -47,11 +58,20 @@ class EventContextHolder:
     @classmethod
     @asynccontextmanager
     async def with_async_context(
-        cls, context_id: IdType, context_flow_id: IdType, event_name: str, user_id: str = None
+        cls,
+        context_id: IdType,
+        context_flow_id: IdType,
+        event_name: str,
+        event_version: int,
+        user_id: str = None,
     ):
         try:
             event_context = EventContext(
-                id=context_id, flow_id=context_flow_id, event_name=event_name, user_id=user_id
+                id=context_id,
+                flow_id=context_flow_id,
+                event_name=event_name,
+                user_id=user_id,
+                event_version=event_version,
             )
             cls.set(event_context)
             yield cls.get()

--- a/events_protocol/core/logging/__init__.py
+++ b/events_protocol/core/logging/__init__.py
@@ -1,42 +1,84 @@
 import json
 import logging
 import queue
+import re
 import sys
+import typing
 from logging.handlers import QueueHandler, QueueListener
 
 from events_protocol.core.context import EventContextHolder
+from datetime import datetime as dt
 
-logging.basicConfig(level=logging.INFO, format="%(message)s")
-_queue = queue.Queue(-1)
-_queue_handler = QueueHandler(_queue)
-_handler = logging.NullHandler()
-_queue_listener = QueueListener(_queue, _handler)
 
-_logger = logging.getLogger("gb.application")
-_logger.addHandler(_queue_handler)
-_queue_listener.start()
+def _get_klass_name(klass: typing.Any) -> str:
+    # Simple and effective
+    return re.sub(r"|".join(map(re.escape, ["<class", "'", ">", " "])), "", str(klass))
+
+
+_logger: logging.LoggerAdapter = None
+
+
+def _get_logger() -> logging.LoggerAdapter:
+    global _logger
+    if _logger:
+        return _logger
+    logging.basicConfig(level=logging.INFO)
+    _queue = queue.Queue(-1)
+    _queue_handler = QueueHandler(_queue)
+    _handler = logging.StreamHandler(sys.stdout)
+    _queue_listener = QueueListener(_queue, _handler)
+
+    _logger = logging.getLogger("gb.events_protocol")
+    if _logger.hasHandlers():
+        _logger.handlers.clear()
+    _logger.addHandler(_queue_handler)
+    _logger.propagate = False
+    _queue_listener.start()
+    return _logger
 
 
 class JsonLogger(logging.LoggerAdapter):
-    def __init__(self,):
-        self.logger = _logger
+    version: str = "NOTDEFINED"
+
+    @classmethod
+    def set_version(cls, version: str):
+        cls.version = version
+
+    def __init__(self, klass=None):
+        self.logger = _get_logger()
+        self.klass = _get_klass_name(klass)
 
     def log(self, level, msg, *args, **kwargs):
         if self.isEnabledFor(level):
+            event_context = EventContextHolder.get()
             _msg = dict(
-                level=logging.getLevelName(level),
-                message=msg,
-                context=EventContextHolder.get().to_dict(),
+                severity=logging.getLevelName(level),
+                logmessage=msg,
+                EventID=event_context.id,
+                FlowID=event_context.flow_id,
+                UserId=event_context.user_id,
+                Operation="{}:v{}".format(event_context.event_name, event_context.event_version),
+                logger=self.klass,
+                LoggerName=self.logger.name,
+                logdate=dt.utcnow().isoformat(),
+                ApplicationVersion=self.version,
             )
+
             extra = kwargs.pop("extra", None)
             if extra:
+                if isinstance(extra, dict):
+                    extra = json.dumps(extra)
+                if not isinstance(extra, str):
+                    extra_type = type(extra)
+                    raise TypeError(
+                        "Extra param needs to be dict or str, not {}".format(extra_type)
+                    )
                 _msg["extra"] = extra
             if level == logging.ERROR and kwargs.get("exc_info"):
                 args = tuple()
                 fmt = logging.Formatter()
                 _exc = sys.exc_info()
-                exc = json.dumps(fmt.formatException(_exc))
-                _msg["stacktrace"] = exc
+                _msg["stackTrace"] = fmt.formatException(_exc)
 
                 kwargs["exc_info"] = False
             msg = json.dumps(_msg)

--- a/events_protocol/core/logging/mixins/loggable.py
+++ b/events_protocol/core/logging/mixins/loggable.py
@@ -3,3 +3,7 @@ from events_protocol.core.logging import JsonLogger
 
 class LoggableMixin:
     logger = JsonLogger()
+
+    def __new__(cls, *args, **kwargs):
+        cls.logger = JsonLogger(cls)
+        return super().__new__(cls)

--- a/events_protocol/core/model/event.py
+++ b/events_protocol/core/model/event.py
@@ -29,7 +29,9 @@ class Event(CamelPydanticMixin):
     @property
     def user_id(self) -> Optional[int]:
         if self.identity is not None:
-            return int(self.identity.get("userId"))
+            user = self.identity.get("userId")
+            if user:
+                return int(user)
 
     @property
     def origin(self) -> Optional[str]:

--- a/events_protocol/server/parser/event_processor.py
+++ b/events_protocol/server/parser/event_processor.py
@@ -59,7 +59,7 @@ class AsyncEventProcessor(EventProcessor):
         try:
             event: Event = cls.parse_event(raw_event)
             async with EventContextHolder.with_async_context(
-                event.id, event.flow_id, event.name
+                event.id, event.flow_id, event.name, event.version, event.user_id
             ) as _:
                 event_handler: AsyncEventHandler = EventDiscovery.get(event.name, event.version)
                 response: ResponseEvent = await event_handler.handle(event)

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,7 @@ setup(
         "requests==2.22.0",
         "urllib3==1.25.8",
     ],
-    extras_require={
-        "doc": [
-            "Sphinx==2.4.1",
-            "sphinx-autoapi==1.2.1",
-        ],
-    },
+    extras_require={"doc": ["Sphinx==2.4.1", "sphinx-autoapi==1.2.1",],},
     project_urls={
         "Documentation": "https://events-protocol.readthedocs.io/en/stable/",
         "Source Code": "https://github.com/GuiaBolso/events-protocol-python",

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -12,7 +12,7 @@ class TestEventContextHolder(TestCase):
     async def test_with_context(self):
         test_event = EventContext(id="my_id", flow_id="my_flow_id", name="test")
         async with EventContextHolder.with_async_context(
-            test_event.id, test_event.flow_id, test_event.event_name
+            test_event.id, test_event.flow_id, test_event.event_name, test_event.event_version
         ) as event_context:
             self.assertEqual(event_context, test_event)
             self.assertEqual(EventContextHolder.get(), test_event)
@@ -24,7 +24,10 @@ class TestEventContextHolder(TestCase):
         async def event_0():
             first_event = EventContext(id=uuid4(), flow_id=uuid4(), name="test")
             async with EventContextHolder.with_async_context(
-                first_event.id, first_event.flow_id, first_event.event_name
+                first_event.id,
+                first_event.flow_id,
+                first_event.event_name,
+                first_event.event_version,
             ) as event_context:
                 assert EventContextHolder.get() == event_context, "EventContext was wrongly set"
                 _events.append({0: EventContextHolder.get()})
@@ -33,7 +36,10 @@ class TestEventContextHolder(TestCase):
         async def event_1():
             second_event = EventContext(id=uuid4(), flow_id=uuid4(), name="test")
             async with EventContextHolder.with_async_context(
-                second_event.id, second_event.flow_id, second_event.event_name
+                second_event.id,
+                second_event.flow_id,
+                second_event.event_name,
+                second_event.event_version,
             ) as event_context:
                 assert EventContextHolder.get() == event_context, "EventContext was wrongly set"
                 _events.append({1: EventContextHolder.get()})


### PR DESCRIPTION
Os logs do kibana não estavam sendo indexados devido ao campo "context" ser confundido com outro campo. Foi retirado o campo context e adicionado os campos default definido nos pattern indexes do kibana GB