### PR TITLE
Importa classes mais utilizadas na raíz da biblioteca

### DIFF
--- a/events_protocol/__init__.py
+++ b/events_protocol/__init__.py
@@ -1,1 +1,9 @@
-__version__ = "0.1.3"  # pragma: no cover
+__version__ = "0.1.4"  # pragma: no cover
+
+from core.builder import EventBuilder
+from client import EventClient
+from core.model.base import BaseModel
+from core.model.event import Event, ResponseEvent
+from server.handler.event_handler import EventHandler
+from server.handler.event_handler_registry import EventRegister
+from server.parser.event_processor import EventProcessor

--- a/events_protocol/__init__.py
+++ b/events_protocol/__init__.py
@@ -1,9 +1,9 @@
 __version__ = "0.1.4"  # pragma: no cover
 
-from core.builder import EventBuilder
-from client import EventClient
-from core.model.base import BaseModel
-from core.model.event import Event, ResponseEvent
-from server.handler.event_handler import EventHandler
-from server.handler.event_handler_registry import EventRegister
-from server.parser.event_processor import EventProcessor
+from .core.builder import EventBuilder
+from .client import EventClient
+from .core.model.base import BaseModel
+from .core.model.event import Event, ResponseEvent
+from .server.handler.event_handler import EventHandler
+from .server.handler.event_handler_registry import EventRegister
+from .server.parser.event_processor import EventProcessor


### PR DESCRIPTION
Hoje é bem difícil lembrar/saber onde cada classe fica. A ideia é transformar isso:
```python
from events_protocol.core.builder import EventBuilder
from events_protocol.core.model.base import BaseModel
from events_protocol.core.model.event import Event, ResponseEvent
from events_protocol.server.handler.event_handler import EventHandler
from events_protocol.server.handler.event_handler_registry import EventRegister
from events_protocol.server.parser.event_processor import EventProcessor
```

Nisso
```python
from events_protocol import EventBuilder, BaseModel,  Event, ResponseEvent, EventHandler, EventRegister, EventProcessor
```