### PR TITLE
Enforce package updates on setup.py

### DIFF
--- a/events_protocol/__init__.py
+++ b/events_protocol/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.5"  # pragma: no cover
+__version__ = "0.1.6"  # pragma: no cover
 
 from .core.builder import EventBuilder
 from .client import EventClient

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,11 @@ setup(
     packages=find_packages(),
     install_requires=[
         "certifi==2021.5.30",
-        "chardet==4.0",
+        "chardet==4.0.*",
         "idna==2.10",
-        "pydantic==1.8",
-        "requests==2.25",
-        "urllib3==1.26",
+        "pydantic==1.8.*",
+        "requests==2.25.*",
+        "urllib3==1.26.*",
     ],
     extras_require={"doc": ["Sphinx==2.4.1", "sphinx-autoapi==1.2.1",],},
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,12 @@ setup(
     license="Apache-2.0",
     packages=find_packages(),
     install_requires=[
-        "certifi==2019.11.28",
-        "chardet==3.0.4",
-        "idna==2.8",
-        "pydantic==1.4",
-        "requests==2.22.0",
-        "urllib3==1.25.8",
+        "certifi==2021.5.30",
+        "chardet==4.0.0",
+        "idna==2.10",
+        "pydantic==1.8.2",
+        "requests==2.25.1",
+        "urllib3==1.26.5",
     ],
     extras_require={"doc": ["Sphinx==2.4.1", "sphinx-autoapi==1.2.1",],},
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,11 @@ setup(
     packages=find_packages(),
     install_requires=[
         "certifi==2021.5.30",
-        "chardet==4.0.0",
+        "chardet==4.0",
         "idna==2.10",
-        "pydantic==1.8.2",
-        "requests==2.25.1",
-        "urllib3==1.26.5",
+        "pydantic==1.8",
+        "requests==2.25",
+        "urllib3==1.26",
     ],
     extras_require={"doc": ["Sphinx==2.4.1", "sphinx-autoapi==1.2.1",],},
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,12 @@ setup(
     license="Apache-2.0",
     packages=find_packages(),
     install_requires=[
-        "certifi==2021.5.30",
-        "chardet==4.0.*",
-        "idna==2.10",
-        "pydantic==1.8.*",
-        "requests==2.25.*",
-        "urllib3==1.26.*",
+        "certifi>=2019.11.28",
+        "chardet>=3.0.4",
+        "idna>=2.8",
+        "pydantic>=1.4",
+        "requests>=2.22.0",
+        "urllib3>=1.25.8",
     ],
     extras_require={"doc": ["Sphinx==2.4.1", "sphinx-autoapi==1.2.1",],},
     project_urls={


### PR DESCRIPTION
Atualização de pacotes deve ser documentada no arquivo `setup.py` e não apenas no `Pipfile.lock` como feito em https://github.com/GuiaBolso/events-protocol-python/pull/15. Este PR corrige essa omissão.