### PR TITLE
Apply linter to codebase

### DIFF
--- a/events_protocol/__init__.py
+++ b/events_protocol/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1"  # pragma: no cover
+__version__ = "0.2.2"  # pragma: no cover
 
 from .core.builder import EventBuilder
 from .client import EventClient

--- a/events_protocol/client/event_client.py
+++ b/events_protocol/client/event_client.py
@@ -36,7 +36,10 @@ class EventClient:
     ) -> ResponseEvent:
         response = self.http_client.post(
             url=self.url,
-            headers={"Content-Type": "application/json", "charset": "UTF-8",},
+            headers={
+                "Content-Type": "application/json",
+                "charset": "UTF-8",
+            },
             payload=request_event.to_json(),
             timeout=timeout or self.default_timeout,
         )

--- a/events_protocol/client/http.py
+++ b/events_protocol/client/http.py
@@ -10,7 +10,12 @@ from .exception.request_exception import TimeoutException, FailedDependencyExcep
 class HttpClient:
     def post(self, url: str, headers: Dict[str, str], payload: str, timeout: int) -> str:
         try:
-            response = requests.post(url=url, headers=headers, data=payload, timeout=timeout,)
+            response = requests.post(
+                url=url,
+                headers=headers,
+                data=payload,
+                timeout=timeout,
+            )
         except (Timeout, ReadTimeout, ConnectTimeout) as exception:
             raise TimeoutException(f"Timeout calling {url}. Error {exception}")
 

--- a/events_protocol/core/exception.py
+++ b/events_protocol/core/exception.py
@@ -8,7 +8,9 @@ class EventException(RuntimeError):
     _TYPE: EventErrorType = EventErrorType.GENERIC
 
     def __init__(
-        self, parameters: Dict[str, Optional[Any]], expected: bool = False,
+        self,
+        parameters: Dict[str, Optional[Any]],
+        expected: bool = False,
     ):
         super().__init__(self._CODE, parameters, self._TYPE, expected)
         self.parameters = parameters

--- a/events_protocol/core/model/user.py
+++ b/events_protocol/core/model/user.py
@@ -8,7 +8,7 @@ class User:
     user_type: Optional[str]
 
     def __hash__(self):
-        return hash(f'{self.user_id},{self.user_type}')
+        return hash(f"{self.user_id},{self.user_type}")
 
     def __eq__(self, other):
         return self.__hash__() == other.__hash__()

--- a/events_protocol/server/handler/event_handler_registry.py
+++ b/events_protocol/server/handler/event_handler_registry.py
@@ -12,6 +12,5 @@ class EventRegister(ABC):
 
     @classmethod
     def register_event(cls):
-        """Call this method on startup application
-        """
+        """Call this method on startup application"""
         EventDiscovery.add(cls.event_name, cls.event_handler, cls.event_version or 1)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,12 @@ setup(
         "requests>=2.22.0",
         "urllib3>=1.25.8",
     ],
-    extras_require={"doc": ["Sphinx==2.4.1", "sphinx-autoapi==1.2.1",],},
+    extras_require={
+        "doc": [
+            "Sphinx==2.4.1",
+            "sphinx-autoapi==1.2.1",
+        ],
+    },
     project_urls={
         "Documentation": "https://events-protocol.readthedocs.io/en/stable/",
         "Source Code": "https://github.com/GuiaBolso/events-protocol-python",

--- a/tests/client/test_event_client.py
+++ b/tests/client/test_event_client.py
@@ -20,7 +20,9 @@ class EventClientTest(TestCase):
             "payload": {"test": "test"},
         }
         response_event = ResponseEvent(
-            name="event:name:response", version=1, payload={"test": "test"},
+            name="event:name:response",
+            version=1,
+            payload={"test": "test"},
         )
 
         post_method.return_value = response_event.to_json()
@@ -37,7 +39,9 @@ class EventClientTest(TestCase):
             "payload": {"test": "test"},
         }
         response_event = ResponseEvent(
-            name="event:name:error", version=1, payload={"test": "test"},
+            name="event:name:error",
+            version=1,
+            payload={"test": "test"},
         )
 
         post_method.return_value = response_event.to_json()

--- a/tests/client/test_http.py
+++ b/tests/client/test_http.py
@@ -58,5 +58,8 @@ class HttpClientTest(TestCase):
 
         with self.assertRaises(FailedDependencyException):
             self.http_client.post(
-                url="http://test.com/", headers=None, payload=None, timeout=1000,
+                url="http://test.com/",
+                headers=None,
+                payload=None,
+                timeout=1000,
             )


### PR DESCRIPTION
Using `black` as a code formatter, this PR updates standards for the entire codebase