### PR TITLE
Add user type to context

### DIFF
--- a/events_protocol/__init__.py
+++ b/events_protocol/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.2"  # pragma: no cover
+__version__ = "0.2.3"  # pragma: no cover
 
 from .core.builder import EventBuilder
 from .client import EventClient

--- a/events_protocol/core/context.py
+++ b/events_protocol/core/context.py
@@ -14,6 +14,7 @@ class EventContext(BaseModel):
     event_name: typing.Optional[str]
     event_version: typing.Optional[int]
     user_id: typing.Optional[str]
+    user_type: typing.Optional[str]
 
 
 _context: ContextVar[EventContext] = ContextVar("event_context", default=None)
@@ -41,6 +42,7 @@ class EventContextHolder:
         event_name: str,
         event_version: int,
         user_id: str = None,
+        user_type: str = None,
     ):
         try:
             event_context = EventContext(
@@ -48,6 +50,7 @@ class EventContextHolder:
                 flow_id=context_flow_id,
                 event_name=event_name,
                 user_id=user_id,
+                user_type=user_type,
                 event_version=event_version,
             )
             cls.set(event_context)
@@ -64,6 +67,7 @@ class EventContextHolder:
         event_name: str,
         event_version: int,
         user_id: str = None,
+        user_type: str = None,
     ):
         try:
             event_context = EventContext(
@@ -71,6 +75,7 @@ class EventContextHolder:
                 flow_id=context_flow_id,
                 event_name=event_name,
                 user_id=user_id,
+                user_type=user_type,
                 event_version=event_version,
             )
             cls.set(event_context)

--- a/events_protocol/core/logging/__init__.py
+++ b/events_protocol/core/logging/__init__.py
@@ -57,6 +57,7 @@ class JsonLogger(logging.LoggerAdapter):
                 EventID=event_context.id,
                 FlowID=event_context.flow_id,
                 UserId=event_context.user_id,
+                UserType=event_context.user_type,
                 Operation="{}:v{}".format(event_context.event_name, event_context.event_version),
                 logger=self.klass,
                 LoggerName=self.logger.name,

--- a/events_protocol/core/model/event.py
+++ b/events_protocol/core/model/event.py
@@ -41,9 +41,10 @@ class Event(CamelPydanticMixin):
     def user_type(self) -> Optional[str]:
         if self.identity is not None:
             user = self.identity.get("user")
-            user_type = user.get("type")
-            if user_type:
-                return user_type
+            if user:
+                user_type = user.get("type")
+                if user_type:
+                    return user_type
         return None
 
     @property

--- a/events_protocol/server/parser/event_processor.py
+++ b/events_protocol/server/parser/event_processor.py
@@ -61,7 +61,7 @@ class AsyncEventProcessor(EventProcessor):
         try:
             event: Event = cls.parse_event(raw_event)
             async with EventContextHolder.with_async_context(
-                event.id, event.flow_id, event.name, event.version, event.user_id
+                event.id, event.flow_id, event.name, event.version, event.user_id, event.user_type
             ) as _:
                 event_handler: AsyncEventHandler = EventDiscovery.get(event.name, event.version)
                 response: ResponseEvent = await event_handler.handle(event)


### PR DESCRIPTION
*Resumo*
O `user_type` não era considerado para o contexto assíncrono da execução. Isso causava um problema no qual o `user_type` era perdido e quebrava a execução do `LCS1` caso o `user_type` fosse usado nos logs `firehose`.

*Valor de negócio*
Permite a utilização do `user_type` na biblioteca